### PR TITLE
Ensure all ZIP entries are created using the same timestamp as the "created" property from content package metadata

### DIFF
--- a/changes.xml
+++ b/changes.xml
@@ -26,6 +26,9 @@
 
     <release version="1.7.6" date="not released">
       <action type="update" dev="sseifert">
+        Ensure all ZIP entries are created using the same timestamp as the "created" property from content package metadata (reproducible builds).
+      </action>
+      <action type="update" dev="sseifert">
         Switch to AEM 6.5.17 as minimum version.
       </action>
     </release>

--- a/changes.xml
+++ b/changes.xml
@@ -25,7 +25,7 @@
   <body>
 
     <release version="1.7.6" date="not released">
-      <action type="update" dev="sseifert">
+      <action type="update" dev="sseifert" issue="12">
         Ensure all ZIP entries are created using the same timestamp as the "created" property from content package metadata (reproducible builds).
       </action>
       <action type="update" dev="sseifert">

--- a/src/main/java/io/wcm/tooling/commons/contentpackagebuilder/ContentPackage.java
+++ b/src/main/java/io/wcm/tooling/commons/contentpackagebuilder/ContentPackage.java
@@ -72,6 +72,7 @@ import io.wcm.tooling.commons.contentpackagebuilder.element.ContentElement;
 public final class ContentPackage implements Closeable {
 
   private final PackageMetadata metadata;
+  private final long entryTime;
   private final ZipOutputStream zip;
   private final Transformer transformer;
   private final XmlContentBuilder xmlContentBuilder;
@@ -86,6 +87,7 @@ public final class ContentPackage implements Closeable {
   @SuppressWarnings("java:S1141") // nested try-catch
   ContentPackage(PackageMetadata metadata, OutputStream os) throws IOException {
     this.metadata = metadata;
+    this.entryTime = metadata.getCreated().getTime();
     this.zip = new ZipOutputStream(os);
 
     TransformerFactory transformerFactory = TransformerFactory.newInstance();
@@ -437,7 +439,7 @@ public final class ContentPackage implements Closeable {
   private void zipPutNextFileEntry(@NotNull String path) throws IOException {
     String folderPath = FilenameUtils.getPath(path);
     ensureFolderPaths(folderPath);
-    zip.putNextEntry(new ZipEntry(path));
+    zip.putNextEntry(newZipEntry(path));
   }
 
   /**
@@ -454,8 +456,14 @@ public final class ContentPackage implements Closeable {
     String parentFolderPath = FilenameUtils.getPath(StringUtils.removeEnd(folderPath, "/"));
     ensureFolderPaths(parentFolderPath);
     // create folder ZIP entry
-    zip.putNextEntry(new ZipEntry(folderPath));
+    zip.putNextEntry(newZipEntry(folderPath));
     folderPaths.add(folderPath);
+  }
+
+  private ZipEntry newZipEntry(String path) {
+    ZipEntry entry = new ZipEntry(path);
+    entry.setTime(this.entryTime);
+    return entry;
   }
 
 }

--- a/src/main/java/io/wcm/tooling/commons/contentpackagebuilder/PackageMetadata.java
+++ b/src/main/java/io/wcm/tooling/commons/contentpackagebuilder/PackageMetadata.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.jackrabbit.util.ISO8601;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Package metadata.
@@ -90,8 +91,13 @@ final class PackageMetadata {
     this.createdBy = createdBy;
   }
 
-  public void setCreated(Date created) {
+  public void setCreated(@NotNull Date created) {
     this.created = created;
+  }
+
+  @NotNull
+  Date getCreated() {
+    return this.created;
   }
 
   public void setVersion(String version) {


### PR DESCRIPTION
reproducible builds